### PR TITLE
chore: remove “Yours?” link from 2024 edition

### DIFF
--- a/2024.html
+++ b/2024.html
@@ -94,7 +94,6 @@
             <li><a href="https://blakewatson.com/">Blake Watson</a></li>
             <li><a href="https://kayserifserif.place/">Katherine Yang</a></li>
             <li><a href="https://cssence.com/">Matthias Zöchling</a></li>
-            <li><a href="https://github.com/css-naked-day/css-naked-day.github.io/edit/master/2024.html"><strong>Yours?</strong></a></li>
           </ol>
         </section>
 


### PR DESCRIPTION
Missed to remove this—would only add this to each next edition.