### PR TITLE
Add Samir Talwar's blog to 2025

### DIFF
--- a/2025.html
+++ b/2025.html
@@ -77,6 +77,7 @@
             <li><a href="https://ariscript.org/">Ari Prakash</a></li>
             <li><a href="https://davidroessli.com/">David Roessli</a></li>
             <li><a href="https://omz13.com/">David Somers</a></li>
+            <li><a href="https://functional.computer/">Samir Talwar</a></li>
             <li><a href="https://tommi.space/">tommi.space</a></li>
             <li><a href="https://villepreux.net/">Antoine Villepreux</a></li>
             <li><a href="https://silvanzwick.com/">Silvan Zwick</a></li>


### PR DESCRIPTION
The URL is https://functional.computer/, and the CSS has already been removed.